### PR TITLE
Added layout configuration option for first region start angle.

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,6 +245,7 @@
           margin: 125,
           arcPadding: 0.04,
           layout: {
+            alpha: 85, // start angle for first region, zero is up North
             threshold: 50000,
             labelThreshold: 5000,
             colors: 'cd3d08 ec8f00 6dae29 683f92 b60275 2058a5 00a592 009d3c 378974 ffca00'.split(' ').map(function(c) { return '#' + c; })

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -30,9 +30,10 @@
     config.targetPadding = config.targetPadding || 20;
     config.labelPadding = config.labelPadding || 10;
     config.labelRadius = config.labelRadius || (config.outerRadius + config.labelPadding);
+    config.layout.alpha = config.layout.alpha || 0; // start angle for first region (0, zero, is up North)
 
     // animation
-    var aLittleBit = Math.PI / 100000;
+    var aLittleBit = π / 100000;
     config.animationDuration = config.animationDuration || 1000;
     config.initialAngle = config.initialAngle || {};
     config.initialAngle.arc = config.initialAngle.arc || { startAngle: 0, endAngle: aLittleBit };
@@ -72,12 +73,17 @@
       countries: []
     };
 
+    Number.prototype.mod = function (n) {
+            return ((this % n) + n) % n;
+    }
+
     // calculate label position
     function labelPosition(angle) {
+      var temp = angle.mod(2*π);
       return {
-        x: Math.cos(angle - π / 2) * config.labelRadius,
-        y: Math.sin(angle - π / 2) * config.labelRadius,
-        r: (angle - π / 2) * 180 / π
+        x: Math.cos(temp - π / 2) * config.labelRadius,
+        y: Math.sin(temp - π / 2) * config.labelRadius,
+        r: (temp - π / 2) * 180 / π
       };
     }
 
@@ -129,6 +135,9 @@
     }
     if (config.layout.sortChors) {
       layout.sortChors(config.layout.sortChords);
+    }
+    if (config.layout.alpha) {
+      layout.alpha(config.layout.alpha);
     }
 
     // chord path generator
@@ -528,13 +537,13 @@
         })
         .attr('transform', function(d) {
           if (d.id !== d.region) {
-            return d.angle > Math.PI ? 'translate(0, -4) rotate(180)' : 'translate(0, 4)';
+            return d.angle.mod(2*π) > π ? 'translate(0, -4) rotate(180)' : 'translate(0, 4)';
           }
         })
         .attr('text-anchor', function(d) {
           return d.id === d.region ?
             'middle' :
-            (d.angle > Math.PI ? 'end' : 'start');
+            (d.angle.mod(2*π) > π ? 'end' : 'start');
         })
         .style('fill', function(d) {
           return d.id === d.region ? arcColor(d) : null;
@@ -559,7 +568,7 @@
         .duration(config.animationDuration)
         .attrTween("d", function(d) {
           var i = d3.interpolate(previous.groups[d.id] || previous.groups[d.region] || meltPreviousGroupArc(d) || config.initialAngle.arc, d);
-          if (d.angle > Math.PI/2 && d.angle < Math.PI*3/2) {
+          if (d.angle > π/2 && d.angle < π*3/2) {
             return function (t) {
               return textPathArc2(i(t)); 
             };
@@ -582,7 +591,7 @@
       groupTextPath
         .text(function(d) { return data.names[d.id]; })
         .attr('startOffset', function(d) {
-          if (d.angle > Math.PI/2 && d.angle < Math.PI*3/2) {
+          if (d.angle > π/2 && d.angle < π*3/2) {
             return '75%';
           } else {
             return '25%';

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -13,7 +13,9 @@
 
   // import "../arrays/range";
   // import "../math/trigonometry";
-  var π = Math.PI;
+  var π = Math.PI,
+      radians = π / 180,
+      degrees = 180 / π;
 
   scope.layout = function() {
     var chord = {},
@@ -29,7 +31,8 @@
         threshold = null,
         sortGroups,
         sortSubgroups,
-        sortChords;
+        sortChords,
+        alpha;
 
     // get region from country index
     function region(index) {
@@ -104,7 +107,7 @@
 
       // Compute the start and end angle for each group and subgroup.
       // Note: Opera has a bug reordering object literal properties!
-      x = 0, i = -1; while (++i < n) {
+      x = alpha, i = -1; while (++i < n) {
         var inflow = 0;
         var outflow = 0;
 
@@ -320,6 +323,22 @@
       if (!groups) relayout();
       return groups;
     };
+
+    // start angle for first region (decimal degrees)
+    // (stored internally in radians)
+    chord.alpha = function(x) {
+      if (!arguments.length) return alpha * degrees;
+      alpha = (x === 0) ? 0.00001 : x; // small but not zero
+      alpha *= radians;
+      alpha = alpha.mod(2*π);
+      chords = groups = null;
+      return chord;
+    };
+
+    // proper modulus (works taking the sign of the divisor not of the dividend)
+    Number.prototype.mod = function (n) {
+            return ((this % n) + n) % n;
+    }
 
     return chord;
   };


### PR DESCRIPTION
The configuration option `config.layout.alpha` allows to define the
amount of decimal degrees (positive or negative) the first region
will be positioned with respect to 90 degrees, i.e. North.

For example `config.layout.alpha: -85` will make the first region in
the chart start at angle 185 degrees (i.e. 90 - 85 % 360).