### PR TITLE
Factored out years interval as a timeline configuration option.

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,7 +258,8 @@
 
         Globalmigration.timeline(chart, {
           now: now,
-          element: '#timeline'
+          element: '#timeline',
+          incr: 5
         });
 
         chart.draw(now);

--- a/lib/timeline.js
+++ b/lib/timeline.js
@@ -14,6 +14,7 @@
     config = config || {};
     config.element = config.element || 'body';
     config.now = config.now || years[0];
+    config.incr = config.incr || 5; // year span for buttons
 
     var form = d3.select(config.element).append('form');
 
@@ -40,7 +41,7 @@
 
     span.append('label')
       .attr('for', function(d) { return 'year-' + d; })
-      .text(function(d) { return ""+d+"–" + (d+5); });
+      .text(function(d) { return ""+ d + (config.incr === 1 ? "" : "-" + (d + config.incr)); });
 
     // keyboard control
     d3.select(document.body).on('keypress', function() {


### PR DESCRIPTION
It is possible to configure, via `config.timeline.incr` the number of
years for the timeline button label. The default is 5.
When set to 1 no interval is produced.