### PR TITLE
Fixed problem with config.layout.alpha set to zero.

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
           margin: 125,
           arcPadding: 0.04,
           layout: {
-            alpha: 85, // start angle for first region, zero is up North
+            alpha: 0,
             threshold: 50000,
             labelThreshold: 5000,
             colors: 'cd3d08 ec8f00 6dae29 683f92 b60275 2058a5 00a592 009d3c 378974 ffca00'.split(' ').map(function(c) { return '#' + c; })

--- a/lib/chart.js
+++ b/lib/chart.js
@@ -30,7 +30,6 @@
     config.targetPadding = config.targetPadding || 20;
     config.labelPadding = config.labelPadding || 10;
     config.labelRadius = config.labelRadius || (config.outerRadius + config.labelPadding);
-    config.layout.alpha = config.layout.alpha || 0; // start angle for first region (0, zero, is up North)
 
     // animation
     var aLittleBit = π / 100000;
@@ -45,6 +44,7 @@
     config.layout.sortChords = config.layout.sortChords || d3.descending;
     config.layout.threshold = config.layout.threshold || 1000;
     config.layout.labelThreshold = config.layout.labelThreshold || 100000;
+    config.layout.alpha = config.layout.alpha || aLittleBit; // start angle for first region (0, zero, is up North)
 
     config.maxRegionsOpen = config.maxRegionsOpen || 2;
     config.infoPopupDelay = config.infoPopupDelay || 300;
@@ -568,7 +568,7 @@
         .duration(config.animationDuration)
         .attrTween("d", function(d) {
           var i = d3.interpolate(previous.groups[d.id] || previous.groups[d.region] || meltPreviousGroupArc(d) || config.initialAngle.arc, d);
-          if (d.angle > π/2 && d.angle < π*3/2) {
+          if (d.angle.mod(2*π) > π/2 && d.angle.mod(2*π) < π*3/2) {
             return function (t) {
               return textPathArc2(i(t)); 
             };
@@ -591,7 +591,7 @@
       groupTextPath
         .text(function(d) { return data.names[d.id]; })
         .attr('startOffset', function(d) {
-          if (d.angle > π/2 && d.angle < π*3/2) {
+          if (d.angle.mod(2*π) > π/2 && d.angle.mod(2*π) < π*3/2) {
             return '75%';
           } else {
             return '25%';

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -107,7 +107,7 @@
 
       // Compute the start and end angle for each group and subgroup.
       // Note: Opera has a bug reordering object literal properties!
-      x = alpha, i = -1; while (++i < n) {
+      x = chord.alpha(), i = -1; while (++i < n) {
         var inflow = 0;
         var outflow = 0;
 


### PR DESCRIPTION
Config.layout.alpha moved to the right section of config options.
Fixed logic for `alpha` set to zero (sorry I did mess it prevoiusly).
Improved angle comparisons by applying mod(2*pi).