### PR TITLE
resize svg height only when shrinking, not above config.width

### DIFF
--- a/lib/chart.js
+++ b/lib/chart.js
@@ -160,7 +160,10 @@
       var width = svg.node().parentNode.clientWidth;
 
       if (width) {
-        svg.attr('height', width);
+        // make height adapt to shrinking of page
+        if (width < config.width) {
+          svg.attr('height', width);
+        }
       }
     });
 


### PR DESCRIPTION
I personally found resizing above config.width leaving the circular plot in the middle of too big a blank page...so I propose to stick to configured size when enlarging above it.
